### PR TITLE
Temporary fix for issue #3207

### DIFF
--- a/checker/tests/index/Issue3207.java
+++ b/checker/tests/index/Issue3207.java
@@ -1,7 +1,5 @@
 // Test case for https://tinyurl.com/cfissue/3207
 
-// @skip-test until the issue is fixed
-
 import org.checkerframework.checker.index.qual.LTLengthOf;
 import org.checkerframework.common.value.qual.MinLen;
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1229,6 +1229,11 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     (FlowExpressions.ArrayCreation) expressionObj;
             // This is only expected to support array creations in varargs methods
             return arrayCreation.getInitializers().size();
+        } else if (expressionObj instanceof FlowExpressions.ArrayAccess) {
+            List<? extends AnnotationMirror> a = expressionObj.getType().getAnnotationMirrors();
+            for (AnnotationMirror i : a) {
+                return getMinLenValue(canonicalAnnotation(i));
+            }
         }
 
         lengthAnno = getAnnotationFromReceiver(expressionObj, tree, ArrayLenRange.class);

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1230,9 +1230,15 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             // This is only expected to support array creations in varargs methods
             return arrayCreation.getInitializers().size();
         } else if (expressionObj instanceof FlowExpressions.ArrayAccess) {
-            List<? extends AnnotationMirror> a = expressionObj.getType().getAnnotationMirrors();
-            for (AnnotationMirror i : a) {
-                return getMinLenValue(canonicalAnnotation(i));
+            List<? extends AnnotationMirror> annoList =
+                    expressionObj.getType().getAnnotationMirrors();
+            for (AnnotationMirror anno : annoList) {
+                String ANNO_NAME = anno.getAnnotationType().toString();
+                if (ANNO_NAME.equals(MINLEN_NAME)
+                        || ANNO_NAME.equals(ARRAYLEN_NAME)
+                        || ANNO_NAME.equals(ARRAYLENRANGE_NAME)) {
+                    return getMinLenValue(canonicalAnnotation(anno));
+                }
             }
         }
 


### PR DESCRIPTION
 Annotations related to certain array access nodes are not retrieved and mapped to the Store. It is possible to retrieve the annotation manually and resolve the issue.